### PR TITLE
fix |> 修复 翻译流程详细说明.md 中关于 PR 操作的链接错误

### DIFF
--- a/翻译流程详细说明.md
+++ b/翻译流程详细说明.md
@@ -41,7 +41,7 @@
 3. 开始翻译
 4. 翻译的时候要注意格式，尤其是中英文和代码，可以参看 [这个说明](https://github.com/SwiftGGTeam/translation/blob/master/SwiftGG%20%E6%8E%92%E7%89%88%E6%8C%87%E5%8D%97.md)
 5. 翻译过程中，文章头部需要添加通用头部，具体格式可以参考 [这个说明](https://raw.githubusercontent.com/SwiftGGTeam/translation/master/%E4%B9%A6%E5%86%99%E8%A7%84%E8%8C%83%E5%8F%8ADemo/SwiftGG%E5%8D%9A%E6%96%87%E4%B9%A6%E5%86%99%E8%A7%84%E8%8C%83.md)，还有 [这个例子](https://raw.githubusercontent.com/SwiftGGTeam/translation/master/%E4%B9%A6%E5%86%99%E8%A7%84%E8%8C%83%E5%8F%8ADemo/20160726_simple-barcode-reader-app-swift.md)
-6. 翻译完成后，按照 [这个说明](https://github.com/SwiftGGTeam/translation/blob/master/%E6%96%B0%E7%BF%BB%E8%AF%91%E6%B5%81%E7%A8%8BBeta.md#%E5%A6%82%E4%BD%95%E5%8F%91%E8%B5%B7-pull-request) 创建 Pull Request，在 Pull Request 的内容里关联对应的 Issue，关联方式：把 Issue 页面的网址复制到 Pull Request 信息中，或者直接在 Pull Request 信息中评论 `#11`，11 是对应的 Issue 号
+6. 翻译完成后，按照 [这个说明](https://github.com/SwiftGGTeam/translation/blob/master/%E7%BF%BB%E8%AF%91%E6%B5%81%E7%A8%8B%E6%A6%82%E8%BF%B0%E5%8F%8APR%E8%AF%B4%E6%98%8E.md#%E5%A6%82%E4%BD%95%E5%8F%91%E8%B5%B7-pull-request) 创建 Pull Request，在 Pull Request 的内容里关联对应的 Issue，关联方式：把 Issue 页面的网址复制到 Pull Request 信息中，或者直接在 Pull Request 信息中评论 `#11`，11 是对应的 Issue 号
 
 下面是关联方式的图解：
 


### PR DESCRIPTION
1. 原文件已经被重命名，因此链接出现错误